### PR TITLE
Make GUI float transceiver QoS match serial node

### DIFF
--- a/src/surface/gui/gui/widgets/float_comm.py
+++ b/src/surface/gui/gui/widgets/float_comm.py
@@ -24,13 +24,23 @@ class FloatComm(QWidget):
         self.handle_data_signal.connect(self.handle_data)
         self.handle_serial_signal.connect(self.handle_serial)
         self.handle_data_single_signal.connect(self.handle_single)
-        GUINode().create_signal_subscription(FloatData, 'transceiver_data', self.handle_data_signal,
-                                             qos_profile=QoSPresetProfiles.SENSOR_DATA.value)
-        GUINode().create_signal_subscription(FloatSerial, 'float_serial', self.handle_serial_signal,
-                                             qos_profile=QoSPresetProfiles.SENSOR_DATA.value)
         GUINode().create_signal_subscription(
-            FloatSingle, 'transceiver_single', self.handle_data_single_signal,
-            qos_profile=QoSPresetProfiles.SENSOR_DATA.value
+            FloatData,
+            'transceiver_data',
+            self.handle_data_signal,
+            qos_profile=QoSPresetProfiles.SENSOR_DATA.value,
+        )
+        GUINode().create_signal_subscription(
+            FloatSerial,
+            'float_serial',
+            self.handle_serial_signal,
+            qos_profile=QoSPresetProfiles.SENSOR_DATA.value,
+        )
+        GUINode().create_signal_subscription(
+            FloatSingle,
+            'transceiver_single',
+            self.handle_data_single_signal,
+            qos_profile=QoSPresetProfiles.SENSOR_DATA.value,
         )
 
         info_layout = QVBoxLayout()


### PR DESCRIPTION
# Pull Request

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes QoS mismatch between GUI and serial reader nodes for the float transceiver.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #88 #41 
