### PR TITLE
Remove old GPG keys and use ros2-apt-source instead

### DIFF
--- a/.vscode/ros2_install.sh
+++ b/.vscode/ros2_install.sh
@@ -11,8 +11,9 @@ sudo add-apt-repository universe -y
 # Adding ROS 2 repo to system
 sudo apt-get update
 sudo apt-get install curl -y
-sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $UBUNTU_CODENAME)_all.deb"
+sudo apt install /tmp/ros2-apt-source.deb
 
 # Install pip
 sudo apt-get install python3-pip -y


### PR DESCRIPTION
# Pull Request

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

GPG keys [expired](https://discourse.ros.org/t/ros-signing-key-migration-guide/43937). Update installation to use new ros2-apt-source package. Script from [new install instructions](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #171 